### PR TITLE
Add extra navigation drawer

### DIFF
--- a/src/layouts/default/TheAppBar.vue
+++ b/src/layouts/default/TheAppBar.vue
@@ -1,66 +1,11 @@
 <template>
-    <v-app-bar flat>
+    <v-app-bar density="comfortable">
         <v-app-bar-title>
             <router-link to="/"> MiSArch Online Store </router-link>
         </v-app-bar-title>
         <v-btn disabled prepend-icon="mdi-cart"> Shopping Cart </v-btn>
-        <v-btn prepend-icon="mdi-plus" @click="openAddCategoryDialog">
-            Add Category
-        </v-btn>
-        <v-btn prepend-icon="mdi-plus" @click="openAddProductDialog">
-            Add Product
-        </v-btn>
-        <AddCategoryDialog
-            v-model="addCategoryDialogOpen"
-            @close-addcategorydialog="closeAddCategoryDialog"
-        />
-        <AddProductDialog
-            v-model="addProductDialogOpen"
-            @close-dialog="closeAddProductDialog"
-        />
     </v-app-bar>
 </template>
 
 <script lang="ts" setup>
-import AddCategoryDialog from '@/components/AddCategoryDialog.vue'
-import AddProductDialog from '@/components/AddProductDialog.vue'
-import { ref } from 'vue'
-
-/**
- * Whether or not the "ADD CATEGORY" dialog is open.
- */
-const addCategoryDialogOpen = ref(false)
-
-/**
- * Whether or not the "ADD PRODUCT" dialog is open.
- */
-const addProductDialogOpen = ref(false)
-
-/**
- * Opens the "ADD CATEGORY" dialog.
- */
-function openAddCategoryDialog() {
-    addCategoryDialogOpen.value = true
-}
-
-/**
- * Closes the "ADD CATEGORY" dialog.
- */
-function closeAddCategoryDialog() {
-    addCategoryDialogOpen.value = false
-}
-
-/**
- * Opens the "ADD PRODUCT" dialog.
- */
-function openAddProductDialog() {
-    addProductDialogOpen.value = true
-}
-
-/**
- * Closes the "ADD PRODUCT" dialog.
- */
-function closeAddProductDialog() {
-    addProductDialogOpen.value = false
-}
 </script>

--- a/src/layouts/default/TheAppBar.vue
+++ b/src/layouts/default/TheAppBar.vue
@@ -7,5 +7,4 @@
     </v-app-bar>
 </template>
 
-<script lang="ts" setup>
-</script>
+<script lang="ts" setup></script>

--- a/src/layouts/default/TheDefaultLayout.vue
+++ b/src/layouts/default/TheDefaultLayout.vue
@@ -26,7 +26,13 @@
                 </v-list-group>
             </v-list>
         </v-navigation-drawer>
-        <v-navigation-drawer class="bg-grey-lighten-4" expand-on-hover floating location="right" rail>
+        <v-navigation-drawer
+            class="bg-grey-lighten-4"
+            expand-on-hover
+            floating
+            location="right"
+            rail
+        >
             <v-list density="default" nav>
                 <v-list-item
                     prepend-icon="mdi-playlist-edit"

--- a/src/layouts/default/TheDefaultLayout.vue
+++ b/src/layouts/default/TheDefaultLayout.vue
@@ -1,7 +1,7 @@
 <template>
     <v-app>
         <TheAppBar />
-        <v-navigation-drawer location="start">
+        <v-navigation-drawer location="start" floating>
             <v-list density="compact" nav>
                 <v-list-item
                     title="All Products"
@@ -24,6 +24,20 @@
                         }"
                     ></v-list-item>
                 </v-list-group>
+            </v-list>
+        </v-navigation-drawer>
+        <v-navigation-drawer class="bg-grey-lighten-4" expand-on-hover floating location="right" rail>
+            <v-list density="default" nav>
+                <v-list-item
+                    prepend-icon="mdi-playlist-edit"
+                    title="Manage Products"
+                    :to="{ name: 'Manage Products' }"
+                ></v-list-item>
+                <v-list-item
+                    prepend-icon="mdi-view-dashboard-edit"
+                    title="Manage Categories"
+                    :to="{ name: 'Manage Categories' }"
+                ></v-list-item>
             </v-list>
         </v-navigation-drawer>
         <TheViewPlaceholder />

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -29,6 +29,16 @@ const routes = [
                 name: 'Category',
                 component: () => import('@/views/CategoryView.vue'),
             },
+            {
+                path: 'manage-products',
+                name: 'Manage Products',
+                component: () => import('@/views/ManageProductsView.vue'),
+            },
+            {
+                path: 'manage-categories',
+                name: 'Manage Categories',
+                component: () => import('@/views/ManageCategoriesView.vue'),
+            },
         ],
     },
 ]

--- a/src/views/ManageCategoriesView.vue
+++ b/src/views/ManageCategoriesView.vue
@@ -1,0 +1,36 @@
+<template>
+    <v-app-bar density="compact">
+        <v-spacer></v-spacer>
+        <v-btn prepend-icon="mdi-plus" @click="openAddCategoryDialog">
+            Add Category
+        </v-btn>
+        <AddCategoryDialog
+            v-model="addCategoryDialogOpen"
+            @close-addcategorydialog="closeAddCategoryDialog"
+        />
+    </v-app-bar>
+</template>
+
+<script lang="ts" setup>
+import AddCategoryDialog from '@/components/AddCategoryDialog.vue'
+import { ref } from 'vue'
+
+/**
+ * Whether or not the "ADD CATEGORY" dialog is open.
+ */
+const addCategoryDialogOpen = ref(false)
+
+/**
+ * Opens the "ADD CATEGORY" dialog.
+ */
+function openAddCategoryDialog() {
+    addCategoryDialogOpen.value = true
+}
+
+/**
+ * Closes the "ADD CATEGORY" dialog.
+ */
+function closeAddCategoryDialog() {
+    addCategoryDialogOpen.value = false
+}
+</script>

--- a/src/views/ManageProductsView.vue
+++ b/src/views/ManageProductsView.vue
@@ -1,0 +1,36 @@
+<template>
+    <v-app-bar density="compact">
+        <v-spacer></v-spacer>
+        <v-btn prepend-icon="mdi-plus" @click="openAddProductDialog">
+            Add Product
+        </v-btn>
+        <AddProductDialog
+            v-model="addProductDialogOpen"
+            @close-dialog="closeAddProductDialog"
+        />
+    </v-app-bar>
+</template>
+
+<script lang="ts" setup>
+import AddProductDialog from '@/components/AddProductDialog.vue'
+import { ref } from 'vue'
+
+/**
+ * Whether or not the "ADD PRODUCT" dialog is open.
+ */
+const addProductDialogOpen = ref(false)
+
+/**
+ * Opens the "ADD PRODUCT" dialog.
+ */
+function openAddProductDialog() {
+    addProductDialogOpen.value = true
+}
+
+/**
+ * Closes the "ADD PRODUCT" dialog.
+ */
+function closeAddProductDialog() {
+    addProductDialogOpen.value = false
+}
+</script>


### PR DESCRIPTION
The extra navigation drawer at the right side of a page. Add two new views: One for managing products, one for managing categories. Initially, the views only hold the two dialogs for adding products and categories. Move the app bar buttons for opening the two dialogs to the new views. Add the views to the router index.

[Link to the corresponding Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/6798a39d-9c7b-4fc9-a0fe-2d6ae8f60801)