### PR TITLE
Filter categories of main navigation drawer

### DIFF
--- a/src/graphql/catalog.graphql
+++ b/src/graphql/catalog.graphql
@@ -79,7 +79,8 @@ query getCategoryWithCharacteristicsAndDefaultProductVariants($id: UUID!, $first
   }
 }
 
-# Gets all of the categories and their individual total count of products.
+# Gets all categories and their individual total count of products and all of a category's products. 
+# Note that a product only comes with information regarding its public visibility and its variants' public visibility.
 query getCategoriesWithTotalCountOfProducts($first: Int, $skip: Int, $orderBy: CategoryOrderInput) {
   categories(first: $first, skip: $skip, orderBy: $orderBy) {
     totalCount
@@ -89,6 +90,15 @@ query getCategoriesWithTotalCountOfProducts($first: Int, $skip: Int, $orderBy: C
       name
       products {
         totalCount
+        nodes {
+          isPubliclyVisible
+          variants {
+            totalCount
+            nodes {
+              isPubliclyVisible
+            }
+          }
+        }
       }
     }
   }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -635,7 +635,22 @@ export type GetCategoriesWithTotalCountOfProductsQuery = {
             __typename?: 'Category'
             id: any
             name: string
-            products: { __typename?: 'ProductConnection'; totalCount: number }
+            products: {
+                __typename?: 'ProductConnection'
+                totalCount: number
+                nodes: Array<{
+                    __typename?: 'Product'
+                    isPubliclyVisible: boolean
+                    variants: {
+                        __typename?: 'ProductVariantConnection'
+                        totalCount: number
+                        nodes: Array<{
+                            __typename?: 'ProductVariant'
+                            isPubliclyVisible: boolean
+                        }>
+                    }
+                }>
+            }
         }>
     }
 }
@@ -947,6 +962,15 @@ export const GetCategoriesWithTotalCountOfProductsDocument = gql`
                 name
                 products {
                     totalCount
+                    nodes {
+                        isPubliclyVisible
+                        variants {
+                            totalCount
+                            nodes {
+                                isPubliclyVisible
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Modify the GraphQL query to include information regarding the visibility of the products of a category. Introduce v-if condition to list group of navigation drawer.

[The Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/c0cf5d79-41e9-446b-910e-80c62205b43b)