### PR TITLE
basic authentication support

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,7 @@
+proxy_buffer_size   128k;
+proxy_buffers   4 256k;
+proxy_busy_buffers_size   256k;
+
 server {
     listen 80;
 
@@ -18,6 +22,12 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Host $host;
-        proxy_set_header X-Forwarded-Port $server_port;
+    }
+
+    location /keycloak {
+        proxy_pass http://keycloak:80/keycloak;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "core-js": "^3.29.0",
         "graphql": "^16.8.1",
         "graphql-request": "^6.1.0",
+        "keycloak-js": "^23.0.6",
         "pinia": "^2.0.0",
         "roboto-fontface": "*",
         "vue": "^3.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,5 +3,8 @@
 </template>
 
 <script lang="ts" setup>
-//
+import { useAppStore } from './store/app';
+
+const store = useAppStore();
+store.initLogin();
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,8 @@
 </template>
 
 <script lang="ts" setup>
-import { useAppStore } from './store/app';
+import { useAppStore } from './store/app'
 
-const store = useAppStore();
-store.initLogin();
+const store = useAppStore()
+store.initLogin()
 </script>

--- a/src/assets/silent-check-sso.html
+++ b/src/assets/silent-check-sso.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+<body>
+    <script>
+        parent.postMessage(location.href, location.origin);
+    </script>
+</body>
+</html>

--- a/src/layouts/default/TheAppBar.vue
+++ b/src/layouts/default/TheAppBar.vue
@@ -4,7 +4,22 @@
             <router-link to="/"> MiSArch Online Store </router-link>
         </v-app-bar-title>
         <v-btn disabled prepend-icon="mdi-cart"> Shopping Cart </v-btn>
+        <v-btn @click="loginOrLogout">
+            {{ store.isLoggedIn ? 'Logout' : 'Login' }}
+        </v-btn>
     </v-app-bar>
 </template>
 
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+import { useAppStore } from '@/store/app'
+
+const store = useAppStore()
+
+function loginOrLogout() {
+    if (store.isLoggedIn) {
+        store.logout()
+    } else {
+        store.login()
+    }
+}
+</script>

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -1,8 +1,51 @@
 // Utilities
+import Keycloak from 'keycloak-js'
 import { defineStore } from 'pinia'
+import silentCheckSsoHtmlUrl from '@/assets/silent-check-sso.html?url'
 
 export const useAppStore = defineStore('app', {
     state: () => ({
-        //
+        keycloak: null as Keycloak | null,
+        isLoggedIn: false,
     }),
+    actions: {
+        async initLogin() {
+            const keycloak = new Keycloak({
+                url: '/keycloak',
+                realm: 'Misarch',
+                clientId: 'frontend',
+            })
+
+            try {
+                await keycloak.init({
+                    onLoad: 'check-sso',
+                    silentCheckSsoRedirectUri: silentCheckSsoHtmlUrl,
+                    redirectUri: '/',
+                })
+                this.keycloak = keycloak
+                this.isLoggedIn = keycloak.authenticated ?? false
+                console.log('Token', keycloak.token)
+            } catch (error) {
+                console.error('Failed to initialize adapter:', error)
+            }
+        },
+        async login() {
+            try {
+                await this.keycloak?.login({
+                    redirectUri: '/',
+                })
+            } catch (error) {
+                console.error('Failed to login:', error)
+            }
+        },
+        async logout() {
+            try {
+                await this.keycloak?.logout({
+                    redirectUri: '/',
+                })
+            } catch (error) {
+                console.error('Failed to logout:', error)
+            }
+        },
+    },
 })

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -9,6 +9,10 @@ export const useAppStore = defineStore('app', {
         isLoggedIn: false,
     }),
     actions: {
+        /**
+         * Initialize the Keycloak adapter.
+         * Also silently checks the SSO session.
+         */
         async initLogin() {
             const keycloak = new Keycloak({
                 url: '/keycloak',
@@ -29,6 +33,9 @@ export const useAppStore = defineStore('app', {
                 console.error('Failed to initialize adapter:', error)
             }
         },
+        /**
+         * Logs the user in.
+         */
         async login() {
             try {
                 await this.keycloak?.login({
@@ -38,6 +45,9 @@ export const useAppStore = defineStore('app', {
                 console.error('Failed to login:', error)
             }
         },
+        /**
+         * Logs the user out.
+         */
         async logout() {
             try {
                 await this.keycloak?.logout({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,7 +2579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -3876,6 +3876,7 @@ __metadata:
     eslint-plugin-vue: "npm:^9.19.2"
     graphql: "npm:^16.8.1"
     graphql-request: "npm:^6.1.0"
+    keycloak-js: "npm:^23.0.6"
     pinia: "npm:^2.0.0"
     prettier: "npm:3.1.1"
     roboto-fontface: "npm:*"
@@ -4616,6 +4617,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-sha256@npm:^0.10.1":
+  version: 0.10.1
+  resolution: "js-sha256@npm:0.10.1"
+  checksum: 10c0/c63119f7c7f8afc24bfa24c1a6b51147c3b562316b6341a375a1cef88569340ec0dbf2cda429ecf472cabfbae47a0b93a0cb82b8730883de066593c3f816c53b
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -4706,6 +4714,24 @@ __metadata:
   version: 0.0.1
   resolution: "jsonify@npm:0.0.1"
   checksum: 10c0/7f5499cdd59a0967ed35bda48b7cec43d850bbc8fb955cdd3a1717bb0efadbe300724d5646de765bb7a99fc1c3ab06eb80d93503c6faaf99b4ff50a3326692f6
+  languageName: node
+  linkType: hard
+
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
+  languageName: node
+  linkType: hard
+
+"keycloak-js@npm:^23.0.6":
+  version: 23.0.6
+  resolution: "keycloak-js@npm:23.0.6"
+  dependencies:
+    base64-js: "npm:^1.5.1"
+    js-sha256: "npm:^0.10.1"
+    jwt-decode: "npm:^4.0.0"
+  checksum: 10c0/2201d7c8cbd9bf556b212895afc1bf68fa4fed47e8f1ac64f96dbfff56e29d182e89d6729f5097ee41910ea8e6284192735483cd274deeb2da7e41d7164c4af1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds very crude and basic authentication support
- extends the nginx conf to proxy keycloak correctly
- silently checks the authenticatin status in App.vue (so basically always)
- adds a Login/Logout button to the top bar
- for dev purposes, logs the token to the dev console (we need this for now to debug with the gateway, see Gropius issue for more details)

https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/5fdb2086-3cc7-41ed-81c2-f5ec6de920ae

- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented