### PR TITLE
Add basic support for tax rates:

### DIFF
--- a/src/components/AddProductDialog.vue
+++ b/src/components/AddProductDialog.vue
@@ -101,6 +101,14 @@
                                 v-model="variant.retailPrice"
                             >
                             </v-text-field>
+                            <v-select
+                                chips
+                                label="Tax Rate"
+                                :items="allTaxRates?.taxRates.nodes"
+                                item-title="name"
+                                item-value="id"
+                                v-model="variant.taxRateId"
+                            ></v-select>
                             <v-file-input
                                 accept="image/*"
                                 chips
@@ -170,6 +178,7 @@ interface ProductVariant {
     description: string
     name: string
     retailPrice: string
+    taxRateId: string | undefined
 }
 
 /**
@@ -225,6 +234,17 @@ const allCategories = computed(
 )
 
 /**
+ * The available tax rates.
+ */
+const allTaxRates = asyncComputed(
+    async () => {
+        return client.getTaxRates()
+    },
+    null,
+    { shallow: false }
+)
+
+/**
  * Adds a product variant template to the dialog
  * so the user can add another product variant.
  */
@@ -236,6 +256,7 @@ function addVariant() {
         description: '',
         name: internalName.value ?? '',
         retailPrice: '0',
+        taxRateId: undefined,
     }
     variants.value.push(createdVariant)
     variantTab.value = createdVariant.tempId
@@ -272,6 +293,7 @@ function transformVariant(
             name: variant.name,
             numericalCharacteristicValues: [],
             retailPrice: Number.parseInt(variant.retailPrice),
+            taxRateId: variant.taxRateId,
         },
         isPubliclyVisible: !variant.invisible,
     }
@@ -310,6 +332,7 @@ async function save() {
                         name: variant.name,
                         numericalCharacteristicValues: [],
                         retailPrice: Number.parseInt(variant.retailPrice),
+                        taxRateId: variant.taxRateId,
                     },
                     isPubliclyVisible: !variant.invisible,
                 }

--- a/src/components/AddTaxRateDialog.vue
+++ b/src/components/AddTaxRateDialog.vue
@@ -1,0 +1,163 @@
+<template>
+    <v-dialog max-width="504">
+        <v-card>
+            <v-card-item>
+                <v-card-title>Add Tax Rate</v-card-title>
+            </v-card-item>
+            <v-card-text>
+                <div class="d-flex flex-column ga-4">
+                    <v-alert
+                        closable
+                        density="comfortable"
+                        text="The given input cannot be saved."
+                        title="Cannot Save"
+                        type="error"
+                        v-model="cannotSave"
+                    ></v-alert>
+                    <v-text-field
+                        clearable
+                        label="Name"
+                        type="input"
+                        v-model="name"
+                    >
+                    </v-text-field>
+                    <v-text-field
+                        clearable
+                        label="Description"
+                        type="input"
+                        v-model="description"
+                    >
+                    </v-text-field>
+                    <v-text-field
+                        clearable
+                        hint="Enter a positive decimal number, e.g. 0.19"
+                        label="Rate"
+                        type="input"
+                        v-model="rate"
+                    >
+                    </v-text-field>
+                    <v-alert
+                        closable
+                        density="comfortable"
+                        text="The rate must be a positive decimal number, e.g. 0.19."
+                        title="Invalid Format"
+                        type="error"
+                        v-model="rateIsInvalid"
+                    ></v-alert>
+                </div>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn prepend-icon="mdi-close" @click="cancel"> Cancel </v-btn>
+                <v-btn prepend-icon="mdi-content-save" @click="save">
+                    Save
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { CreateTaxRateInput } from '@/graphql/generated'
+import { ref } from 'vue'
+
+/**
+ * The emits of this component:
+ * close-addtaxratedialog -- The dialog has to be closed.
+ * add-tax-rate -- The given tax rate has to be added.
+ */
+const emit = defineEmits<{
+    (event: 'close-addtaxratedialog'): void
+    (event: 'add-tax-rate', input: CreateTaxRateInput): void
+}>()
+
+/**
+ * The name of the tax rate.
+ */
+const name = ref('')
+
+/**
+ * The description of the tax rate.
+ */
+const description = ref('')
+
+/**
+ * The rate of the initial tax rate version.
+ */
+const rate = ref('')
+
+/**
+ * Whether or not the tax rate can be saved.
+ */
+const cannotSave = ref(false)
+
+/**
+ * Whether or not the entered rate is invalid.
+ */
+const rateIsInvalid = ref(false)
+
+/**
+ * Resets every mutable property of this view.
+ */
+function resetViewModel() {
+    name.value = ''
+    description.value = ''
+    rate.value = ''
+}
+
+/**
+ * Resets the view model and
+ * emits the 'close-addtaxratedialog' event.
+ */
+function cancel() {
+    resetViewModel()
+
+    emit('close-addtaxratedialog')
+}
+
+/**
+ * Emits the 'add-tax-rate' event and
+ * resets the view model
+ * if the tax rate can be saved.
+ */
+function save() {
+    cannotSave.value = false
+    rateIsInvalid.value = false
+
+    if (canSave()) {
+        const input: CreateTaxRateInput = {
+            name: name.value,
+            description: description.value,
+            initialVersion: {
+                rate: parseFloat(rate.value),
+            },
+        }
+
+        emit('add-tax-rate', input)
+
+        resetViewModel()
+    }
+}
+
+/**
+ * Evaluates whether or not the provided tax rate input can be saved --
+ * if the provided input is valid.
+ */
+function canSave(): boolean {
+    const canSave =
+        rateIsValid() && name.value.length > 0 && description.value.length > 0
+    cannotSave.value = !canSave
+    return canSave
+}
+
+/**
+ * Evaluates whether or not the provided input for the rate
+ * of the initial tax rate version is valid.
+ */
+function rateIsValid(): boolean {
+    const rateAsFloat = parseFloat(rate.value)
+    const rateIsValid = rateAsFloat >= 0
+    rateIsInvalid.value = !rateIsValid
+    return rateIsValid
+}
+</script>

--- a/src/components/AddTaxRateVersionDialog.vue
+++ b/src/components/AddTaxRateVersionDialog.vue
@@ -1,0 +1,119 @@
+<template>
+    <v-dialog max-width="504">
+        <v-card>
+            <v-card-item>
+                <v-card-title>Add Tax Rate Version</v-card-title>
+            </v-card-item>
+            <v-card-text>
+                <div class="d-flex flex-column ga-4">
+                    <v-text-field
+                        clearable
+                        hint="Enter a positive decimal number, e.g. 0.19"
+                        label="Rate"
+                        type="input"
+                        v-model="rate"
+                    >
+                    </v-text-field>
+                    <v-alert
+                        closable
+                        density="comfortable"
+                        text="The rate must be a positive decimal number, e.g. 0.19."
+                        title="Invalid Format"
+                        type="error"
+                        v-model="rateIsInvalid"
+                    ></v-alert>
+                </div>
+            </v-card-text>
+            <v-card-actions>
+                <v-spacer></v-spacer>
+                <v-btn prepend-icon="mdi-close" @click="cancel"> Cancel </v-btn>
+                <v-btn prepend-icon="mdi-content-save" @click="save">
+                    Save
+                </v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
+</template>
+
+<script lang="ts" setup>
+import { CreateTaxRateVersionInput } from '@/graphql/generated'
+import { ref } from 'vue'
+
+/**
+ * The props of this component.
+ */
+const props = defineProps({
+    taxRateId: {
+        type: String,
+        required: true,
+    },
+})
+
+/**
+ * The emits of this component:
+ * close-addtaxrateversiondialog -- The dialog has to be closed.
+ * add-tax-rate-version -- The given tax rate version has to be added.
+ */
+const emit = defineEmits<{
+    (event: 'close-addtaxrateversiondialog'): void
+    (event: 'add-tax-rate-version', input: CreateTaxRateVersionInput): void
+}>()
+
+/**
+ * The rate of the initial tax rate version.
+ */
+const rate = ref('')
+
+/**
+ * Whether or not the entered rate is invalid.
+ */
+const rateIsInvalid = ref(false)
+
+/**
+ * Resets every mutable property of this view.
+ */
+function resetViewModel() {
+    rate.value = ''
+}
+
+/**
+ * Resets the view model and
+ * emits the 'close-addtaxratedialog' event.
+ */
+function cancel() {
+    resetViewModel()
+
+    emit('close-addtaxrateversiondialog')
+}
+
+/**
+ * Emits the 'add-tax-rate-version' event and
+ * resets the view model
+ * if the tax rate version can be saved -- if the provided rate is valid.
+ */
+function save() {
+    rateIsInvalid.value = false
+
+    if (rateIsValid()) {
+        const input: CreateTaxRateVersionInput = {
+            rate: parseFloat(rate.value),
+            taxRateId: props.taxRateId,
+        }
+
+        emit('add-tax-rate-version', input)
+
+        resetViewModel()
+    }
+}
+
+/**
+ * Evaluates whether or not the provided input for the rate
+ * of the initial tax rate version is valid.
+ */
+function rateIsValid(): boolean {
+    const rateAsFloat = parseFloat(rate.value)
+    const rateIsValid = rateAsFloat >= 0
+    rateIsInvalid.value = !rateIsValid
+    return rateIsValid
+}
+</script>

--- a/src/graphql/catalog.graphql
+++ b/src/graphql/catalog.graphql
@@ -142,6 +142,17 @@ query getProduct($id: UUID!) {
           description
           retailPrice
           canBeReturnedForDays
+          taxRate {
+            id
+            name
+            description
+            currentVersion {
+              id
+              rate
+              version
+              createdAt
+            }
+          }
           version
           createdAt
           characteristicValues {

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -32,9 +32,7 @@ export type Scalars = {
     Float: { input: number; output: number }
     Date: { input: any; output: any }
     DateTime: { input: any; output: any }
-    FieldSet: { input: any; output: any }
     UUID: { input: any; output: any }
-    _Any: { input: any; output: any }
 }
 
 export type AddShoppingCartItemInput = {
@@ -235,11 +233,26 @@ export type CreateProductVariantVersionInput = {
     productVariantId: Scalars['UUID']['input']
     /** The retail price of the ProductVariant. */
     retailPrice: Scalars['Int']['input']
+    /** The associated TaxRate */
+    taxRateId: Scalars['UUID']['input']
 }
 
-export type CreateUserDtoInput = {
+/** Input for the createTaxRate mutation */
+export type CreateTaxRateInput = {
+    /** The description of the created TaxRate */
+    description: Scalars['String']['input']
+    /** The initial version of the created TaxRate */
+    initialVersion: TaxRateVersionInput
+    /** The name of the created TaxRate */
     name: Scalars['String']['input']
-    username: Scalars['String']['input']
+}
+
+/** Input for the createTaxRateVersion mutation */
+export type CreateTaxRateVersionInput = {
+    /** The rate of the created TaxRateVersion */
+    rate: Scalars['Float']['input']
+    /** The id of the TaxRate the created TaxRateVersion belongs to */
+    taxRateId: Scalars['UUID']['input']
 }
 
 /** The gender of a user */
@@ -286,11 +299,11 @@ export type NumericalCategoryCharacteristicValueInput = {
     value: Scalars['Float']['input']
 }
 
-/** GraphQL order direction. */
+/** Order direction */
 export enum OrderDirection {
-    /** Ascending order direction. */
+    /** Ascending order */
     Asc = 'ASC',
-    /** Descending order direction. */
+    /** Descending order */
     Desc = 'DESC',
 }
 
@@ -360,6 +373,8 @@ export type ProductVariantVersionInput = {
     numericalCharacteristicValues: Array<NumericalCategoryCharacteristicValueInput>
     /** The retail price of the ProductVariant. */
     retailPrice: Scalars['Int']['input']
+    /** The associated TaxRate */
+    taxRateId: Scalars['UUID']['input']
 }
 
 /** ProductVariantVersion order fields */
@@ -387,12 +402,62 @@ export type ShoppingCartItemInput = {
     productVariantId: Scalars['UUID']['input']
 }
 
+/** TaxRate order fields */
+export enum TaxRateOrderField {
+    /** Order TaxRates by their id */
+    Id = 'ID',
+    /** Order TaxRates by their name */
+    Name = 'NAME',
+}
+
+/** TaxRate order */
+export type TaxRateOrderInput = {
+    /** The direction to order by */
+    direction?: InputMaybe<OrderDirection>
+    /** The field to order by */
+    field?: InputMaybe<TaxRateOrderField>
+}
+
+/** Input for creating a TaxRateVersion */
+export type TaxRateVersionInput = {
+    /** The rate of the created TaxRateVersion */
+    rate: Scalars['Float']['input']
+}
+
+/** TaxRateVersion order fields */
+export enum TaxRateVersionOrderField {
+    /** Order TaxRateVersions by their creation date */
+    CreatedAt = 'CREATED_AT',
+    /** Order TaxRateVersions by their id */
+    Id = 'ID',
+    /** Order TaxRateVersions by their version */
+    Version = 'VERSION',
+}
+
+/** TaxRateVersion order */
+export type TaxRateVersionOrderInput = {
+    /** The direction to order by */
+    direction?: InputMaybe<OrderDirection>
+    /** The field to order by */
+    field?: InputMaybe<TaxRateVersionOrderField>
+}
+
 /** Input for the updateNotification mutation */
 export type UpdateNotificationInput = {
     /** id of the notification to update */
     id: Scalars['UUID']['input']
     /** mark the notification as read/unread */
     isRead: Scalars['Boolean']['input']
+}
+
+/** Input for the updateProduct mutation. */
+export type UpdateProductInput = {
+    /** UUID of the product to be updated */
+    id: Scalars['UUID']['input']
+    /** If present, new value for internalName */
+    internalName?: InputMaybe<Scalars['String']['input']>
+    /** If present, new value for isPubliclyVisible */
+    isPubliclyVisible?: InputMaybe<Scalars['Boolean']['input']>
 }
 
 /** The input of a product item update */
@@ -403,6 +468,14 @@ export type UpdateProductItemInput = {
     isInInventory: Scalars['Boolean']['input']
     /** The product variant id of the product item */
     productVariantId: Scalars['UUID']['input']
+}
+
+/** Input for the updateProductVariant mutation. */
+export type UpdateProductVariantInput = {
+    /** UUID of the product variant to be updated */
+    id: Scalars['UUID']['input']
+    /** If present, new value for isPubliclyVisible */
+    isPubliclyVisible?: InputMaybe<Scalars['Boolean']['input']>
 }
 
 export type UpdateShoppingCartInput = {
@@ -419,6 +492,16 @@ export type UpdateShoppingCartItemInput = {
     id: Scalars['UUID']['input']
 }
 
+/** Input for the updateTaxRate mutation */
+export type UpdateTaxRateInput = {
+    /** If provided, the new description of the TaxRate */
+    description?: InputMaybe<Scalars['String']['input']>
+    /** The id of the TaxRate to update */
+    id: Scalars['UUID']['input']
+    /** If provided, the new name of the TaxRate */
+    name?: InputMaybe<Scalars['String']['input']>
+}
+
 export type UpdateWishlistInput = {
     /** UUID of wishlist to update. */
     id: Scalars['UUID']['input']
@@ -426,6 +509,22 @@ export type UpdateWishlistInput = {
     name?: InputMaybe<Scalars['String']['input']>
     /** product variant UUIDs of wishlist to update */
     productVariantIds?: InputMaybe<Array<Scalars['UUID']['input']>>
+}
+
+/** User order fields */
+export enum UserOrderField {
+    /** Order users by their id */
+    Id = 'ID',
+    /** Order users by their username */
+    Username = 'USERNAME',
+}
+
+/** User order */
+export type UserOrderInput = {
+    /** The direction to order by */
+    direction?: InputMaybe<OrderDirection>
+    /** The field to order by */
+    field?: InputMaybe<UserOrderField>
 }
 
 /** Describes the fields that a wishlist can be ordered by. */
@@ -728,6 +827,19 @@ export type GetProductQuery = {
                     canBeReturnedForDays?: number | null
                     version: number
                     createdAt: any
+                    taxRate: {
+                        __typename?: 'TaxRate'
+                        id: any
+                        name: string
+                        description: string
+                        currentVersion: {
+                            __typename?: 'TaxRateVersion'
+                            id: any
+                            rate: number
+                            version: number
+                            createdAt: any
+                        }
+                    }
                     characteristicValues: {
                         __typename?: 'CategoryCharacteristicValueConnection'
                         totalCount: number
@@ -854,6 +966,158 @@ export type CreateNumericalCategoryCharacteristicMutation = {
     }
 }
 
+export type TaxRateVersionFragment = {
+    __typename?: 'TaxRateVersion'
+    id: any
+    rate: number
+    version: number
+    createdAt: any
+}
+
+export type GetTaxRatesQueryVariables = Exact<{
+    first?: InputMaybe<Scalars['Int']['input']>
+    skip?: InputMaybe<Scalars['Int']['input']>
+    orderBy?: InputMaybe<TaxRateOrderInput>
+}>
+
+export type GetTaxRatesQuery = {
+    __typename?: 'Query'
+    taxRates: {
+        __typename?: 'TaxRateConnection'
+        totalCount: number
+        hasNextPage: boolean
+        nodes: Array<{
+            __typename?: 'TaxRate'
+            id: any
+            name: string
+            description: string
+        }>
+    }
+}
+
+export type GetTaxRatesWithVersionsQueryVariables = Exact<{
+    first?: InputMaybe<Scalars['Int']['input']>
+    skip?: InputMaybe<Scalars['Int']['input']>
+    orderBy?: InputMaybe<TaxRateOrderInput>
+}>
+
+export type GetTaxRatesWithVersionsQuery = {
+    __typename?: 'Query'
+    taxRates: {
+        __typename?: 'TaxRateConnection'
+        totalCount: number
+        hasNextPage: boolean
+        nodes: Array<{
+            __typename?: 'TaxRate'
+            id: any
+            name: string
+            description: string
+            currentVersion: { __typename?: 'TaxRateVersion'; id: any }
+            versions: {
+                __typename?: 'TaxRateVersionConnection'
+                totalCount: number
+                nodes: Array<{
+                    __typename?: 'TaxRateVersion'
+                    id: any
+                    rate: number
+                    version: number
+                    createdAt: any
+                }>
+            }
+        }>
+    }
+}
+
+export type GetTaxRatesWithCurrentVersionQueryVariables = Exact<{
+    first?: InputMaybe<Scalars['Int']['input']>
+    skip?: InputMaybe<Scalars['Int']['input']>
+    orderBy?: InputMaybe<TaxRateOrderInput>
+}>
+
+export type GetTaxRatesWithCurrentVersionQuery = {
+    __typename?: 'Query'
+    taxRates: {
+        __typename?: 'TaxRateConnection'
+        totalCount: number
+        hasNextPage: boolean
+        nodes: Array<{
+            __typename?: 'TaxRate'
+            id: any
+            name: string
+            description: string
+            currentVersion: {
+                __typename?: 'TaxRateVersion'
+                id: any
+                rate: number
+                version: number
+                createdAt: any
+            }
+        }>
+    }
+}
+
+export type GetTaxRateQueryVariables = Exact<{
+    id: Scalars['UUID']['input']
+    firstVersions?: InputMaybe<Scalars['Int']['input']>
+    skipVersion?: InputMaybe<Scalars['Int']['input']>
+    orderByVersions?: InputMaybe<TaxRateVersionOrderInput>
+}>
+
+export type GetTaxRateQuery = {
+    __typename?: 'Query'
+    taxRate: {
+        __typename?: 'TaxRate'
+        id: any
+        name: string
+        description: string
+        currentVersion: {
+            __typename?: 'TaxRateVersion'
+            id: any
+            rate: number
+            version: number
+            createdAt: any
+        }
+        versions: {
+            __typename?: 'TaxRateVersionConnection'
+            totalCount: number
+            nodes: Array<{
+                __typename?: 'TaxRateVersion'
+                id: any
+                rate: number
+                version: number
+                createdAt: any
+            }>
+        }
+    }
+}
+
+export type CreateTaxRateMutationVariables = Exact<{
+    input: CreateTaxRateInput
+}>
+
+export type CreateTaxRateMutation = {
+    __typename?: 'Mutation'
+    createTaxRate: { __typename?: 'TaxRate'; id: any }
+}
+
+export type CreateTaxRateVersionMutationVariables = Exact<{
+    input: CreateTaxRateVersionInput
+}>
+
+export type CreateTaxRateVersionMutation = {
+    __typename?: 'Mutation'
+    createTaxRateVersion: { __typename?: 'TaxRateVersion'; id: any }
+}
+
+export type UpdateTaxRateMutationVariables = Exact<{
+    input: UpdateTaxRateInput
+}>
+
+export type UpdateTaxRateMutation = {
+    __typename?: 'Mutation'
+    updateTaxRate: { __typename?: 'TaxRate'; id: any }
+}
+
 export const CurrentVersionFragmentDoc = gql`
     fragment currentVersion on ProductVariantVersion {
         id
@@ -898,6 +1162,14 @@ export const CharacteristicFragmentDoc = gql`
         ... on NumericalCategoryCharacteristic {
             unit
         }
+    }
+`
+export const TaxRateVersionFragmentDoc = gql`
+    fragment taxRateVersion on TaxRateVersion {
+        id
+        rate
+        version
+        createdAt
     }
 `
 export const GetDefaultProductVariantsDocument = gql`
@@ -1020,6 +1292,17 @@ export const GetProductDocument = gql`
                         description
                         retailPrice
                         canBeReturnedForDays
+                        taxRate {
+                            id
+                            name
+                            description
+                            currentVersion {
+                                id
+                                rate
+                                version
+                                createdAt
+                            }
+                        }
                         version
                         createdAt
                         characteristicValues {
@@ -1098,6 +1381,116 @@ export const CreateNumericalCategoryCharacteristicDocument = gql`
         $input: CreateNumericalCategoryCharacteristicInput!
     ) {
         createNumericalCategoryCharacteristic(input: $input) {
+            id
+        }
+    }
+`
+export const GetTaxRatesDocument = gql`
+    query getTaxRates($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
+        taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+            totalCount
+            hasNextPage
+            nodes {
+                id
+                name
+                description
+            }
+        }
+    }
+`
+export const GetTaxRatesWithVersionsDocument = gql`
+    query getTaxRatesWithVersions(
+        $first: Int
+        $skip: Int
+        $orderBy: TaxRateOrderInput
+    ) {
+        taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+            totalCount
+            hasNextPage
+            nodes {
+                id
+                name
+                description
+                currentVersion {
+                    id
+                }
+                versions {
+                    totalCount
+                    nodes {
+                        ...taxRateVersion
+                    }
+                }
+            }
+        }
+    }
+    ${TaxRateVersionFragmentDoc}
+`
+export const GetTaxRatesWithCurrentVersionDocument = gql`
+    query getTaxRatesWithCurrentVersion(
+        $first: Int
+        $skip: Int
+        $orderBy: TaxRateOrderInput
+    ) {
+        taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+            totalCount
+            hasNextPage
+            nodes {
+                id
+                name
+                description
+                currentVersion {
+                    ...taxRateVersion
+                }
+            }
+        }
+    }
+    ${TaxRateVersionFragmentDoc}
+`
+export const GetTaxRateDocument = gql`
+    query getTaxRate(
+        $id: UUID!
+        $firstVersions: Int
+        $skipVersion: Int
+        $orderByVersions: TaxRateVersionOrderInput
+    ) {
+        taxRate(id: $id) {
+            id
+            name
+            description
+            currentVersion {
+                ...taxRateVersion
+            }
+            versions(
+                first: $firstVersions
+                skip: $skipVersion
+                orderBy: $orderByVersions
+            ) {
+                totalCount
+                nodes {
+                    ...taxRateVersion
+                }
+            }
+        }
+    }
+    ${TaxRateVersionFragmentDoc}
+`
+export const CreateTaxRateDocument = gql`
+    mutation createTaxRate($input: CreateTaxRateInput!) {
+        createTaxRate(input: $input) {
+            id
+        }
+    }
+`
+export const CreateTaxRateVersionDocument = gql`
+    mutation createTaxRateVersion($input: CreateTaxRateVersionInput!) {
+        createTaxRateVersion(input: $input) {
+            id
+        }
+    }
+`
+export const UpdateTaxRateDocument = gql`
+    mutation updateTaxRate($input: UpdateTaxRateInput!) {
+        updateTaxRate(input: $input) {
             id
         }
     }
@@ -1294,6 +1687,118 @@ export function getSdk(
                         { ...requestHeaders, ...wrappedRequestHeaders }
                     ),
                 'createNumericalCategoryCharacteristic',
+                'mutation',
+                variables
+            )
+        },
+        getTaxRates(
+            variables?: GetTaxRatesQueryVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<GetTaxRatesQuery> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<GetTaxRatesQuery>(
+                        GetTaxRatesDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'getTaxRates',
+                'query',
+                variables
+            )
+        },
+        getTaxRatesWithVersions(
+            variables?: GetTaxRatesWithVersionsQueryVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<GetTaxRatesWithVersionsQuery> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<GetTaxRatesWithVersionsQuery>(
+                        GetTaxRatesWithVersionsDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'getTaxRatesWithVersions',
+                'query',
+                variables
+            )
+        },
+        getTaxRatesWithCurrentVersion(
+            variables?: GetTaxRatesWithCurrentVersionQueryVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<GetTaxRatesWithCurrentVersionQuery> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<GetTaxRatesWithCurrentVersionQuery>(
+                        GetTaxRatesWithCurrentVersionDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'getTaxRatesWithCurrentVersion',
+                'query',
+                variables
+            )
+        },
+        getTaxRate(
+            variables: GetTaxRateQueryVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<GetTaxRateQuery> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<GetTaxRateQuery>(
+                        GetTaxRateDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'getTaxRate',
+                'query',
+                variables
+            )
+        },
+        createTaxRate(
+            variables: CreateTaxRateMutationVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<CreateTaxRateMutation> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<CreateTaxRateMutation>(
+                        CreateTaxRateDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'createTaxRate',
+                'mutation',
+                variables
+            )
+        },
+        createTaxRateVersion(
+            variables: CreateTaxRateVersionMutationVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<CreateTaxRateVersionMutation> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<CreateTaxRateVersionMutation>(
+                        CreateTaxRateVersionDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'createTaxRateVersion',
+                'mutation',
+                variables
+            )
+        },
+        updateTaxRate(
+            variables: UpdateTaxRateMutationVariables,
+            requestHeaders?: GraphQLClientRequestHeaders
+        ): Promise<UpdateTaxRateMutation> {
+            return withWrapper(
+                (wrappedRequestHeaders) =>
+                    client.request<UpdateTaxRateMutation>(
+                        UpdateTaxRateDocument,
+                        variables,
+                        { ...requestHeaders, ...wrappedRequestHeaders }
+                    ),
+                'updateTaxRate',
                 'mutation',
                 variables
             )

--- a/src/graphql/tax.graphql
+++ b/src/graphql/tax.graphql
@@ -9,7 +9,7 @@ fragment taxRateVersion on TaxRateVersion {
 
 # Queries:
 
-# TODO
+# Gets all of the tax rates without any related entities.
 query getTaxRates($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
     taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
         totalCount
@@ -22,7 +22,8 @@ query getTaxRates($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
     }
 }
 
-# TODO
+# Gets all of the tax rates including their versions and
+# the ID of the current version.
 query getTaxRatesWithVersions($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
     taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
         totalCount
@@ -44,7 +45,7 @@ query getTaxRatesWithVersions($first: Int, $skip: Int, $orderBy: TaxRateOrderInp
     }
 }
 
-# TODO
+# Gets all of the tax rates including the entire current tax rate version entity (of the type TaxRateVersion).
 query getTaxRatesWithCurrentVersion($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
     taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
         totalCount
@@ -60,7 +61,7 @@ query getTaxRatesWithCurrentVersion($first: Int, $skip: Int, $orderBy: TaxRateOr
     }
 }
 
-# TODO
+# Gets a single tax rate including its related TaxRateVersions (currentVersion and versions).
 query getTaxRate($id: UUID!, $firstVersions: Int, $skipVersion: Int, $orderByVersions: TaxRateVersionOrderInput) {
   taxRate(id: $id) {
     id
@@ -78,37 +79,23 @@ query getTaxRate($id: UUID!, $firstVersions: Int, $skipVersion: Int, $orderByVer
   }
 }
 
-fragment taxRateVersion on TaxRateVersion {
-  id
-  rate
-  version
-  createdAt
-}
-
-fragment taxRateVersion on TaxRateVersion {
-  id
-  rate
-  version
-  createdAt
-}
-
 # Mutations:
 
-# TODO
+# Creates a single tax rate.
 mutation createTaxRate($input: CreateTaxRateInput!) {
   createTaxRate(input: $input) {
     id
   }
 }
 
-# TODO
+# Creates a single tax rate version.
 mutation createTaxRateVersion($input: CreateTaxRateVersionInput!) {
   createTaxRateVersion(input: $input) {
     id
   }
 }
 
-# TODO
+# Updates an existing tax rate.
 mutation updateTaxRate($input: UpdateTaxRateInput!) {
   updateTaxRate(input: $input) {
     id

--- a/src/graphql/tax.graphql
+++ b/src/graphql/tax.graphql
@@ -1,0 +1,116 @@
+# Fragments:
+
+fragment taxRateVersion on TaxRateVersion {
+  id
+  rate
+  version
+  createdAt
+}
+
+# Queries:
+
+# TODO
+query getTaxRates($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
+    taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+        totalCount
+        hasNextPage
+        nodes {
+            id
+            name
+            description
+        }
+    }
+}
+
+# TODO
+query getTaxRatesWithVersions($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
+    taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+        totalCount
+        hasNextPage
+        nodes {
+            id
+            name
+            description
+            currentVersion {
+                id
+            }
+            versions {
+                totalCount
+                nodes {
+                    ... taxRateVersion
+                }
+            }
+        }
+    }
+}
+
+# TODO
+query getTaxRatesWithCurrentVersion($first: Int, $skip: Int, $orderBy: TaxRateOrderInput) {
+    taxRates(first: $first, skip: $skip, orderBy: $orderBy) {
+        totalCount
+        hasNextPage
+        nodes {
+            id
+            name
+            description
+            currentVersion {
+                ... taxRateVersion
+            }
+        }
+    }
+}
+
+# TODO
+query getTaxRate($id: UUID!, $firstVersions: Int, $skipVersion: Int, $orderByVersions: TaxRateVersionOrderInput) {
+  taxRate(id: $id) {
+    id
+    name
+    description
+    currentVersion {
+      ...taxRateVersion
+    }
+    versions(first: $firstVersions, skip: $skipVersion, orderBy: $orderByVersions) {
+      totalCount
+      nodes {
+        ...taxRateVersion
+      }
+    }
+  }
+}
+
+fragment taxRateVersion on TaxRateVersion {
+  id
+  rate
+  version
+  createdAt
+}
+
+fragment taxRateVersion on TaxRateVersion {
+  id
+  rate
+  version
+  createdAt
+}
+
+# Mutations:
+
+# TODO
+mutation createTaxRate($input: CreateTaxRateInput!) {
+  createTaxRate(input: $input) {
+    id
+  }
+}
+
+# TODO
+mutation createTaxRateVersion($input: CreateTaxRateVersionInput!) {
+  createTaxRateVersion(input: $input) {
+    id
+  }
+}
+
+# TODO
+mutation updateTaxRate($input: UpdateTaxRateInput!) {
+  updateTaxRate(input: $input) {
+    id
+  }
+}

--- a/src/layouts/default/TheDefaultLayout.vue
+++ b/src/layouts/default/TheDefaultLayout.vue
@@ -47,6 +47,11 @@
                     title="Manage Categories"
                     :to="{ name: 'Manage Categories' }"
                 ></v-list-item>
+                <v-list-item
+                    prepend-icon="mdi-file-percent"
+                    title="Manage Tax Rates"
+                    :to="{ name: 'Manage Tax Rates' }"
+                ></v-list-item>
             </v-list>
         </v-navigation-drawer>
         <TheViewPlaceholder />

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -39,6 +39,16 @@ const routes = [
                 name: 'Manage Categories',
                 component: () => import('@/views/ManageCategoriesView.vue'),
             },
+            {
+                path: 'manage-tax-rates',
+                name: 'Manage Tax Rates',
+                component: () => import('@/views/ManageTaxRatesView.vue'),
+            },
+            {
+                path: 'tax-rates/:taxrateid',
+                name: 'Tax Rate',
+                component: () => import('@/views/TaxRateView.vue'),
+            },
         ],
     },
 ]

--- a/src/views/ManageTaxRatesView.vue
+++ b/src/views/ManageTaxRatesView.vue
@@ -1,0 +1,145 @@
+<template>
+    <v-toolbar class="bg-grey-lighten-3" density="comfortable">
+        <v-toolbar-title>Manage Tax Rates</v-toolbar-title>
+        <v-spacer></v-spacer>
+        <v-btn prepend-icon="mdi-plus" @click="openAddTaxRateDialog">
+            Add Tax Rate
+        </v-btn>
+        <AddTaxRateDialog
+            v-model="addTaxRateDialogOpen"
+            @close-addtaxratedialog="closeAddTaxRateDialog"
+            @add-tax-rate="addTaxRate"
+        />
+    </v-toolbar>
+    <v-alert
+        class="ma-2"
+        closable
+        density="comfortable"
+        text="An error occurred when trying to add the tax rate."
+        title="Could not add tax rate"
+        type="error"
+        v-model="addingTaxRateFailed"
+    ></v-alert>
+    <v-list
+        v-if="taxRates != null && taxRates && taxRates.taxRates.totalCount > 0"
+        class="mx-2"
+        lines="three"
+    >
+        <v-list-item
+            v-for="taxRate in taxRates.taxRates.nodes"
+            :value="taxRate.id"
+            @click="navigateToTaxRate(taxRate.id)"
+        >
+            <v-list-item-title>{{ taxRate.name }}</v-list-item-title>
+            <v-list-item-subtitle>{{
+                taxRate.description
+            }}</v-list-item-subtitle>
+        </v-list-item>
+    </v-list>
+</template>
+
+<script lang="ts" setup>
+import AddTaxRateDialog from '@/components/AddTaxRateDialog.vue'
+import { CreateTaxRateInput } from '@/graphql/generated'
+import { useClient } from '@/graphql/client'
+import { asyncComputed } from '@vueuse/core'
+import { ref } from 'vue'
+import router from '@/router'
+
+/**
+ * The GraphQL client to use for all GraphQL requests.
+ */
+const client = useClient()
+
+/**
+ * This prop is used for triggering a reevaluation
+ * of the async computed prop 'taxRates'.
+ */
+const trigger = ref(0)
+
+/**
+ * Triggers the async computed prop 'taxRates' to be reevaluated.
+ */
+function reevaluateTaxRates() {
+    trigger.value++
+}
+
+/**
+ * The tax rates.
+ */
+const taxRates = asyncComputed(
+    async () => {
+        trigger.value
+        try {
+            return await client.getTaxRatesWithCurrentVersion()
+        } catch (error) {
+            console.error(error)
+
+            return null
+        }
+    },
+    null,
+    { shallow: false }
+)
+
+/**
+ * Whether or not the "ADD TAX RATE" dialog is open.
+ */
+const addTaxRateDialogOpen = ref(false)
+
+/**
+ * Opens the "ADD TAX RATE" dialog.
+ */
+function openAddTaxRateDialog() {
+    addTaxRateDialogOpen.value = true
+}
+
+/**
+ * Closes the "ADD TAX RATE" dialog.
+ */
+function closeAddTaxRateDialog() {
+    addTaxRateDialogOpen.value = false
+}
+
+/**
+ * Whether or not adding a new tax rate failed.
+ */
+const addingTaxRateFailed = ref(false)
+
+/**
+ * Closes the 'ADD TAX RATE' dialog and
+ * then tries to request the creation of a new tax rate
+ * according to the given CreateTaxRateInput.
+ * The tax rates will be reloaded if the new one is created.
+ * @param input The tax rate to add.
+ */
+async function addTaxRate(input: CreateTaxRateInput) {
+    closeAddTaxRateDialog()
+
+    addingTaxRateFailed.value = false
+    try {
+        await client.createTaxRate({
+            input: input,
+        })
+
+        reevaluateTaxRates()
+    } catch (error) {
+        addingTaxRateFailed.value = true
+
+        console.error(error)
+    }
+}
+
+/**
+ * Navigates to the tax rate matching the given ID.
+ * @param taxRateId The ID of the tax rate to navigate to.
+ */
+function navigateToTaxRate(taxRateId: any) {
+    router.push({
+        name: 'Tax Rate',
+        params: {
+            taxrateid: taxRateId,
+        },
+    })
+}
+</script>

--- a/src/views/ProductView.vue
+++ b/src/views/ProductView.vue
@@ -91,6 +91,20 @@
                         />
                     </div>
                 </v-card-text>
+                <v-divider class="mx-4"></v-divider>
+                <v-card-text>
+                    <v-chip
+                        @click="
+                            navigateToTaxRate(
+                                productVariant?.currentVersion.taxRate.id
+                            )
+                        "
+                        >Tax Rate:
+                        {{
+                            productVariant?.currentVersion.taxRate.name
+                        }}</v-chip
+                    >
+                </v-card-text>
             </v-card>
         </div>
         <div class="d-flex flex-column ga-4">
@@ -438,6 +452,20 @@ function navigateToCategory(id: any) {
         name: 'Category',
         params: {
             categoryid: id,
+        },
+    })
+}
+
+/**
+ * Navigates to the tax rate to which the given ID belongs.
+ * The navigation is done via the Vue Router.
+ * @param id The ID of the category to navigate to.
+ */
+function navigateToTaxRate(id: any) {
+    router.push({
+        name: 'Tax Rate',
+        params: {
+            taxrateid: id,
         },
     })
 }

--- a/src/views/TaxRateView.vue
+++ b/src/views/TaxRateView.vue
@@ -1,0 +1,234 @@
+<template>
+    <div class="d-flex flex-column ga-4">
+        <div>
+            <v-toolbar class="bg-grey-lighten-3" density="comfortable">
+                <v-btn icon="mdi-arrow-left" @click="router.back()"></v-btn>
+                <v-spacer></v-spacer>
+                <v-btn
+                    prepend-icon="mdi-plus"
+                    @click="openAddTaxRateVersionDialog"
+                >
+                    Add Tax Rate Version
+                </v-btn>
+                <AddTaxRateVersionDialog
+                    :tax-rate-id="taxRate?.taxRate.id"
+                    v-model="addTaxRateVersionDialogOpen"
+                    @close-addtaxrateversiondialog="
+                        closeAddTaxRateVersionDialog
+                    "
+                    @add-tax-rate-version="addTaxRateVersion"
+                />
+            </v-toolbar>
+            <v-card class="bg-grey-lighten-3" rounded="0" variant="flat">
+                <v-card-item>
+                    <v-card-title class="mr-1">
+                        Tax Rate: {{ taxRate?.taxRate.name }}
+                    </v-card-title>
+
+                    <v-card-subtitle
+                        >ID: {{ taxRate?.taxRate.id }}</v-card-subtitle
+                    >
+                </v-card-item>
+                <v-card-text>
+                    Number of versions:
+                    {{ taxRate?.taxRate.versions.totalCount }}
+                </v-card-text>
+            </v-card>
+            <v-card class="bg-grey-lighten-4" rounded="0" variant="flat">
+                <v-card-item>
+                    <v-card-title
+                        >Current Version:
+                        {{
+                            taxRate?.taxRate.currentVersion.version
+                        }}</v-card-title
+                    >
+                    <v-card-subtitle
+                        >ID:
+                        {{
+                            taxRate?.taxRate.currentVersion.id
+                        }}</v-card-subtitle
+                    >
+                </v-card-item>
+                <v-card-text>
+                    <div v-if="taxRate?.taxRate.currentVersion.createdAt">
+                        Created
+                        <RelativeTime
+                            :time="taxRate?.taxRate.currentVersion.createdAt"
+                        />
+                    </div>
+                </v-card-text>
+            </v-card>
+        </div>
+        <div class="d-flex flex-column ga-4">
+            <div class="d-flex mx-4 ga-4">
+                <v-card class="align-self-start" elevation="4">
+                    <v-card-item>
+                        <v-card-title
+                            >Current Rate:
+                            {{
+                                taxRate?.taxRate.currentVersion.rate
+                            }}</v-card-title
+                        >
+                    </v-card-item>
+                    <v-divider></v-divider>
+                    <v-card-item>
+                        <v-card-title>Description</v-card-title>
+                    </v-card-item>
+                    <v-card-text>{{
+                        taxRate?.taxRate.description
+                    }}</v-card-text>
+                </v-card>
+            </div>
+            <v-card
+                v-if="taxRateVersions && taxRateVersions.length > 0"
+                class="mx-4 mb-4"
+                elevation="4"
+            >
+                <v-card-item>
+                    <v-card-title> Version History </v-card-title>
+                </v-card-item>
+                <v-card-text>
+                    <v-list density="comfortable" lines="two">
+                        <v-list-item v-for="taxRateVersion in taxRateVersions">
+                            <v-list-item-title
+                                >Version
+                                {{ taxRateVersion.version }}</v-list-item-title
+                            >
+                            <v-list-item-subtitle
+                                >Rate:
+                                {{ taxRateVersion.rate }}</v-list-item-subtitle
+                            >
+                        </v-list-item>
+                    </v-list>
+                </v-card-text>
+            </v-card>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import AddTaxRateVersionDialog from '@/components/AddTaxRateVersionDialog.vue'
+import RelativeTime from '@/components/RelativeTime.vue'
+import { useClient } from '@/graphql/client'
+import {
+    CreateTaxRateVersionInput,
+    OrderDirection,
+    TaxRateVersionOrderField,
+} from '@/graphql/generated'
+import { asyncComputed } from '@vueuse/core'
+import { computed, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+/**
+ * The GraphQL client to use for all GraphQL requests.
+ */
+const client = useClient()
+
+/**
+ * The current route (location).
+ */
+const route = useRoute()
+
+/**
+ * The router.
+ */
+const router = useRouter()
+
+/**
+ * The tax rate id (taken from the route params).
+ */
+const id = computed(() => {
+    return route.params.taxrateid.toString()
+})
+
+/**
+ * This prop is used for triggering a reevaluation
+ * of the async computed prop 'taxRate'.
+ */
+const trigger = ref(0)
+
+/**
+ * Triggers the async computed prop 'taxRates' to be reevaluated.
+ */
+function reevaluateTaxRate() {
+    trigger.value++
+}
+
+/**
+ * The tax rate.
+ */
+const taxRate = asyncComputed(
+    async () => {
+        trigger.value
+        return client.getTaxRate({
+            id: id.value,
+            orderByVersions: {
+                direction: OrderDirection.Asc,
+                field: TaxRateVersionOrderField.Version,
+            },
+        })
+    },
+    null,
+    { shallow: false }
+)
+
+/**
+ * The tax rate versions.
+ * These are listed in the section 'Version History'.
+ */
+const taxRateVersions = computed(() => {
+    if (taxRate.value?.taxRate.versions.totalCount) {
+        return taxRate.value.taxRate.versions.nodes
+    } else {
+        return []
+    }
+})
+
+/**
+ * Whether or not the "ADD TAX RATE VERSION" dialog is open.
+ */
+const addTaxRateVersionDialogOpen = ref(false)
+
+/**
+ * Opens the "ADD TAX RATE VERSION" dialog.
+ */
+function openAddTaxRateVersionDialog() {
+    addTaxRateVersionDialogOpen.value = true
+}
+
+/**
+ * Closes the "ADD TAX RATE VERSION" dialog.
+ */
+function closeAddTaxRateVersionDialog() {
+    addTaxRateVersionDialogOpen.value = false
+}
+
+/**
+ * Whether or not adding a new tax rate version failed.
+ */
+const addingTaxRateVersionFailed = ref(false)
+
+/**
+ * Closes the 'ADD TAX RATE VERSION' dialog and
+ * then tries to request the creation of a new tax rate version
+ * according to the given CreateTaxRateVersionInput.
+ * The tax rate will be reloaded if the new version is created.
+ * @param input The tax rate to add.
+ */
+async function addTaxRateVersion(input: CreateTaxRateVersionInput) {
+    closeAddTaxRateVersionDialog()
+
+    addingTaxRateVersionFailed.value = false
+    try {
+        await client.createTaxRateVersion({
+            input: input,
+        })
+
+        reevaluateTaxRate()
+    } catch (error) {
+        addingTaxRateVersionFailed.value = true
+
+        console.error(error)
+    }
+}
+</script>


### PR DESCRIPTION
Modify ProductView: The product view displays the tax rate of the current product variant version and one can navigate to the page of that tax rate by clicking the corresponding chip.

Modify AddProductDialog: One can set the tax rate for the product variant (its initial version) to add.

Modify and add graphql queries and mutations related to tax rates and products.

Add view for managing tax rates: ManageTaxRatesView: The user can add tax rates there and see the existing ones.

Add view for inspecting single tax rate: TaxRateView.

Two new dialogs: AddTaxRateDialog and AddTaxRateVersionDialog: For creating new tax rates and further tax rate versions of existing tax rates.

[The related Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/8edde482-815e-40de-a7cc-4ee0ab7c3d60)

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented
- [x] GraphQL related artefacts are documented