### PR TITLE
Remove __typename check for currentUser object

### DIFF
--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -142,7 +142,7 @@ export const useAppStore = defineStore('app', {
             try {
                 const getCurrentUserQuery = await useClient().getCurrentUser()
                 const currentUser = getCurrentUserQuery.currentUser
-                if (currentUser !== null && currentUser !== undefined) {
+                if (currentUser != undefined) {
                     return getCurrentUserQuery
                 } else {
                     return null
@@ -164,14 +164,12 @@ export const useAppStore = defineStore('app', {
             const getCurrentUserQuery = await this.getCurrentUser()
             if (getCurrentUserQuery !== null) {
                 const currentUser = getCurrentUserQuery.currentUser
-                if (currentUser !== null && currentUser !== undefined) {
+                if (currentUser != undefined) {
                     this.currentUserId = currentUser.id
                 }
             }
 
-            return (
-                this.currentUserId !== null && this.currentUserId !== undefined
-            )
+            return this.currentUserId != undefined
         },
         /**
          * Sets the user roles of the current user based on the roles retrieved from Keycloak.

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -134,17 +134,16 @@ export const useAppStore = defineStore('app', {
             }
         },
         /**
-         * Retrieves the current user.
+         * Asynchronously retrieves the current user.
          *
-         * @returns A promise that resolves with the current user information or null if:
-         *     a) the user information is not of type 'User' or
-         *     b) the retrieval failed with an error.
+         * @returns A promise that resolves to the current user or null if an error occurs.
          */
         async getCurrentUser(): Promise<GetCurrentUserQuery | null> {
             try {
-                const currentUser = await useClient().getCurrentUser()
-                if (currentUser.currentUser?.__typename === 'User') {
-                    return currentUser
+                const getCurrentUserQuery = await useClient().getCurrentUser()
+                const currentUser = getCurrentUserQuery.currentUser
+                if (currentUser !== null && currentUser !== undefined) {
+                    return getCurrentUserQuery
                 } else {
                     return null
                 }
@@ -157,26 +156,22 @@ export const useAppStore = defineStore('app', {
         /**
          * Sets the current user ID based on the retrieved user information.
          *
-         * @returns A promise that resolves with a boolean indicating whether
-         * the current user ID was successfully set (true) or not (false).
+         * @returns A promise that resolves to true if the current user ID was successfully set, false otherwise.
          */
         async setCurrentUserId(): Promise<boolean> {
-            const currentUser = await this.getCurrentUser()
-            if (
-                currentUser !== null &&
-                currentUser.currentUser?.__typename === 'User'
-            ) {
-                this.currentUserId = currentUser.currentUser.id
+            this.currentUserId = null
 
-                return (
-                    this.currentUserId !== null &&
-                    this.currentUserId !== undefined
-                )
-            } else {
-                this.currentUserId = null
-
-                return false
+            const getCurrentUserQuery = await this.getCurrentUser()
+            if (getCurrentUserQuery !== null) {
+                const currentUser = getCurrentUserQuery.currentUser
+                if (currentUser !== null && currentUser !== undefined) {
+                    this.currentUserId = currentUser.id
+                }
             }
+
+            return (
+                this.currentUserId !== null && this.currentUserId !== undefined
+            )
         },
         /**
          * Sets the user roles of the current user based on the roles retrieved from Keycloak.


### PR DESCRIPTION
- __typename check (=== 'User') would never be true -- this caused the bug in the first place
- instead of checking type name, check null and undefiened
- Restructure code
- Rewrite JSDoc comments

[Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/fc843930-9673-486b-a578-e44f60a5f58c)

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented
- [x] GraphQL related artefacts are documented