### PR TITLE
Introduce two new types for the GraphQL client:

### DIFF
--- a/src/graphql/client.ts
+++ b/src/graphql/client.ts
@@ -3,6 +3,11 @@ import { getSdk } from './generated'
 import { useAppStore } from '@/store/app'
 
 /**
+ * Type simply representing the return type of the useClient function.
+ */
+export type Client = ReturnType<typeof useClient>
+
+/**
  * Gets the GraphQL client to use for all GraphQL requests.
  *
  * @returns The GraphQL client.

--- a/src/graphql/returnTypeOfGraphQLOperation.ts
+++ b/src/graphql/returnTypeOfGraphQLOperation.ts
@@ -1,0 +1,9 @@
+import { Client } from './client'
+
+/**
+ * Type representing the return type of a specific GraphQL operation.
+ * The GraphQL operation must be available to the GraphQL client.
+ */
+export type ReturnTypeOfGraphQLOperation<T extends keyof Client> = Awaited<
+    ReturnType<Client[T]>
+>


### PR DESCRIPTION
Introduce two new types for the GraphQL client:
- Basic type Client that represents the return type of the useClient function.
- Type that represents the return type of a named operation accessible via the Client.

[Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/3d3b991a-0d17-447b-ac4e-6026b087afe8)

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented