### PR TITLE
Add input field: User can set canBeReturnedForDays

### DIFF
--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -128,13 +128,17 @@ export type CategoryOrderInput = {
     field?: InputMaybe<CategoryOrderField>
 }
 
-/** Common order fields */
+/**
+ * Describes the fields that a foreign types can be ordered by.
+ *
+ * Only the Id valid at the moment.
+ */
 export enum CommonOrderField {
-    /** Order entities by their id */
+    /** Orders by "id". */
     Id = 'ID',
 }
 
-/** Discount order */
+/** Specifies the order of foreign types. */
 export type CommonOrderInput = {
     /** The direction to order by */
     direction?: InputMaybe<OrderDirection>
@@ -252,6 +256,19 @@ export type CreateNumericalCategoryCharacteristicInput = {
     name: Scalars['String']['input']
     /** The unit of the NumericalCategoryCharacteristic */
     unit: Scalars['String']['input']
+}
+
+export type CreateOrderInput = {
+    /** UUID of address of invoice. */
+    invoiceAddressId: Scalars['UUID']['input']
+    /** OrderItems of order. */
+    orderItemInputs: Array<OrderItemInput>
+    /** UUID of payment information that the order should be processed with. */
+    paymentInformationId: Scalars['UUID']['input']
+    /** UUID of address to where the order should be shipped to. */
+    shipmentAddressId: Scalars['UUID']['input']
+    /** UUID of user owning the order. */
+    userId: Scalars['UUID']['input']
 }
 
 /** Input for the createProduct mutation */
@@ -517,6 +534,15 @@ export enum OrderDirection {
     Desc = 'DESC',
 }
 
+export type OrderItemInput = {
+    /** UUIDs of coupons to use with order item. */
+    couponIds: Array<Scalars['UUID']['input']>
+    /** UUID of shipment method to use with order item. */
+    shipmentMethodId: Scalars['UUID']['input']
+    /** UUID of shopping cart item associated with order item. */
+    shoppingCartItemId: Scalars['UUID']['input']
+}
+
 /** OrderItem order fields */
 export enum OrderItemOrderField {
     /** Order order items by their id */
@@ -529,6 +555,38 @@ export type OrderItemOrderInput = {
     direction?: InputMaybe<OrderDirection>
     /** The field to order by */
     field?: InputMaybe<OrderItemOrderField>
+}
+
+/** Describes the fields that a order can be ordered by. */
+export enum OrderOrderField {
+    /** Orders by "created_at". */
+    CreatedAt = 'CREATED_AT',
+    /** Orders by "id". */
+    Id = 'ID',
+    /** Orders by "last_updated_at". */
+    LastUpdatedAt = 'LAST_UPDATED_AT',
+    /** Orders by "name". */
+    Name = 'NAME',
+    /** Orders by "user_id". */
+    UserId = 'USER_ID',
+}
+
+/** Specifies the order of orders. */
+export type OrderOrderInput = {
+    /** Order direction of orders. */
+    direction?: InputMaybe<OrderDirection>
+    /** Field that orders should be ordered by. */
+    field?: InputMaybe<OrderOrderField>
+}
+
+/** Describes if Order is placed, or yet pending. An Order can be rejected during its lifetime. */
+export enum OrderStatus {
+    /** Order is saved a a template, this status can only last for max. 1 hour. */
+    Pending = 'PENDING',
+    /** Order is placed, which means SAGA for payment, fullfill and other validity checks need to be triggered. */
+    Placed = 'PLACED',
+    /** Something went wrong with the order and it was compensated in all relevant serivces. */
+    Rejected = 'REJECTED',
 }
 
 /** Filtering options for payments */
@@ -769,6 +827,14 @@ export type RegisterCouponInput = {
     code: Scalars['String']['input']
     /** The user who wants to register the coupon. */
     userId: Scalars['UUID']['input']
+}
+
+/** Describes the reason why an Order was rejected, in case of rejection: `OrderStatus::Rejected`. */
+export enum RejectionReason {
+    /** The order was rejected due to its invalid content. */
+    InvalidOrderData = 'INVALID_ORDER_DATA',
+    /** The inventory service was not able to reserve inventory items according to the order. */
+    InventoryReservationFailed = 'INVENTORY_RESERVATION_FAILED',
 }
 
 /** The input to reserve a batch of product items */

--- a/src/util/rules.ts
+++ b/src/util/rules.ts
@@ -32,3 +32,18 @@ export function weightInputIsValid(input: string): boolean | string {
 
     return 'The weight of the product must be specified. It must be entered as a positive decimal number, e.g., 0.5'
 }
+
+/**
+ * Determines whether the input string is a valid representation of the number of days within which a product version can be returned.
+ * @param input The input string representing the number of days.
+ * @returns Returns true if the input is a valid positive integer or 0, else returns a descriptive error message.
+ */
+export function canBeReturnedWithinNumberOfDaysInputIsValid(
+    input: string
+): boolean | string {
+    if (isNumber(input) && parseInt(input) >= 0) {
+        return true
+    }
+
+    return 'Information on how long the product version can be returned must be provided. It must be entered as a positive integer or 0.'
+}

--- a/src/views/ProductView.vue
+++ b/src/views/ProductView.vue
@@ -380,15 +380,13 @@
                             </v-row>
                             <v-row align="start" dense>
                                 <v-col>Returns:</v-col>
-                                <v-col
-                                    >Returnable within
-                                    {{
-                                        productVariantInfoRelevantToBuyer
-                                            ?.currentVersion
-                                            .canBeReturnedForDays
-                                    }}
-                                    days of receipt.</v-col
-                                >
+                                <v-col v-if="canBeReturnedAtAnyTime">
+                                    Can be returned at any time.
+                                </v-col>
+                                <v-col v-else>
+                                    Returnable within
+                                    {{ canBeReturnedForDays }} days of receipt.
+                                </v-col>
                             </v-row>
                         </v-container>
                     </v-card-text>
@@ -1069,4 +1067,21 @@ async function addToCart() {
         )
     }
 }
+
+/**
+ * Information on how long the product version can be returned, 'measured' in number of days.
+ */
+const canBeReturnedForDays = computed(() => {
+    if (productVariantInfoRelevantToBuyer.value) {
+        return productVariantInfoRelevantToBuyer.value.currentVersion
+            .canBeReturnedForDays
+    }
+})
+
+/**
+ * Whether the current product version can be returned at any time.
+ */
+const canBeReturnedAtAnyTime = computed(() => {
+    return canBeReturnedForDays.value === null
+})
 </script>


### PR DESCRIPTION
- Add checkbox and input field to AddProductDialog: The user can select that the product version can be returned at any time or specify the number of days the product version can be returned within.
- Modify ProductView: Make information regarding returns conditional: Display string saying that product can be returned at any time if the product version can be returned at any time. Else tell user how many days they have to return the item.
- Add rule function to rules.ts

[The Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/5e678eba-e3c4-42bb-a9e9-deba66d908a4)

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented