### PR TITLE
Feature/add back button at checkout

### DIFF
--- a/src/components/SelectOrAddNewCreditCardCard.vue
+++ b/src/components/SelectOrAddNewCreditCardCard.vue
@@ -35,7 +35,8 @@
                             hint="You can find the CVC on the back of your card."
                             label="Credit Card Validation Code (CVC)"
                             :persistent-hint="
-                                order.creditCardValidationCode == undefined
+                                upcomingOrder.creditCardValidationCode ==
+                                undefined
                             "
                             prepend-icon="mdi-numeric"
                             required
@@ -45,7 +46,7 @@
                             ]"
                             type="input"
                             variant="underlined"
-                            v-model="order.creditCardValidationCode"
+                            v-model="upcomingOrder.creditCardValidationCode"
                         ></v-text-field>
                     </v-col>
                 </v-row>
@@ -179,7 +180,7 @@ watch(
 const emits = defineEmits(['update:creditCard', 'newCreditCardSaved'])
 
 const store = useAppStore()
-const { order } = storeToRefs(store)
+const { upcomingOrder } = storeToRefs(store)
 
 const client = useClient()
 

--- a/src/layouts/checkout/TheCheckoutLayout.vue
+++ b/src/layouts/checkout/TheCheckoutLayout.vue
@@ -11,10 +11,13 @@
                 <v-breadcrumbs :items="checkoutStages" />
                 <v-spacer></v-spacer>
                 <v-btn
-                    :disabled="userCannotCancel"
                     prepend-icon="mdi-close"
-                    @click="onUserWantsToCancel"
-                    >cancel</v-btn
+                    @click="onUserWantsToCancelOrLeave"
+                    >{{
+                        !userHasArrivedAtCheckoutSummary
+                            ? 'cancel'
+                            : 'leave checkout'
+                    }}</v-btn
                 >
                 <v-btn
                     :disabled="backButtonIsDisabled"
@@ -91,9 +94,9 @@ const userHasArrivedAtCheckoutSummary = computed(() => {
 })
 
 /**
- * Whether the user cannot cancel the checkout process.
+ * Whether the order has been placed or not.
  */
-const userCannotCancel = computed(() => {
+const orderHasBeenPlaced = computed(() => {
     return userHasArrivedAtCheckoutSummary.value
 })
 
@@ -221,12 +224,13 @@ function onUserConfirmedCancellation(): void {
 }
 
 /**
- * Opens the the dialog that lets the user confirm (or cancel)
- * the cancelation of the checkout if the user has not arrived at
- * the checkout summary. If the user has actually already arrived at
- * the checkout summary, the function simply initiates the cancellation of the checkout.
+ * Opens a dialog that lets the user confirm (or cancel)
+ * the cancelation of the checkout if the order has not been placed yet.
+ * If the order has already been placed
+ * the function simply initiates the cancellation of the checkout
+ * which means that the user gets sent back to the storefront.
  */
-function onUserWantsToCancel(): void {
+function onUserWantsToCancelOrLeave(): void {
     if (userHasArrivedAtCheckoutSummary.value) {
         cancel()
     } else {
@@ -235,11 +239,11 @@ function onUserWantsToCancel(): void {
 }
 
 /**
- * Navigates to the shopping cart page using the router and resets the order information.
+ * Navigates to the storefront using the router and resets the order information.
  */
 function cancel(): void {
     router.push({
-        name: routeNames.shoppingCart,
+        name: routeNames.storefront,
     })
     store.resetOrderToUndefined()
 }

--- a/src/model/classes/orderImpl.ts
+++ b/src/model/classes/orderImpl.ts
@@ -10,12 +10,14 @@ import { PaymentInformation } from '../interfaces/PaymentInformation'
 export class OrderImpl implements Order {
     /**
      * Creates an instance of OrderInformationImpl.
+     * @param hasBeenPlaced - Whether the order has been placed or not.
      * @param [items] - The items that make up the order.
      * @param [deliveryAddress] - The delivery address for the order.
      * @param [billingAddress] - The billing address for the order.
      * @param [paymentInformation] - The payment information for the order.
      */
     constructor(
+        public hasBeenPlaced: boolean,
         public items?: OrderItem[],
         public deliveryAddress?: Address,
         public billingAddress?: Address,

--- a/src/model/interfaces/order.ts
+++ b/src/model/interfaces/order.ts
@@ -5,6 +5,7 @@ import { PaymentInformation } from './PaymentInformation'
 /**
  * Interface representing an order.
  * @interface
+ * @property hasBeenPlaced - Whether the order has been placed or not.
  * @property [items] - The items that make up the order.
  * @property [deliveryAddress] - The delivery address for the order.
  * @property [billingAddress] - The billing address for the order.
@@ -12,6 +13,7 @@ import { PaymentInformation } from './PaymentInformation'
  * @method calculateTotalCost - Calculates the total cost of the order.
  */
 export interface Order {
+    hasBeenPlaced: boolean
     items?: OrderItem[]
     deliveryAddress?: Address
     billingAddress?: Address

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -25,6 +25,11 @@ const defaultUserRole = UserRole.Buyer
 const initialUserRolesOfCurrentUser = [defaultUserRole]
 
 /**
+ * A new and totally empty order that has not yet been created in the backend.
+ */
+const emptyOrderThatHasNotYetBeenPlaced = new OrderImpl(false)
+
+/**
  * Interface representing a notification to be displayed.
  *
  * @property text - The main text content of the notification.
@@ -50,7 +55,7 @@ export const useAppStore = defineStore('app', {
         activeUserRole: defaultUserRole,
         queuedNotifications: [] as Notification[],
         shoppingCart: emptyShoppingCart,
-        order: new OrderImpl(),
+        upcomingOrder: emptyOrderThatHasNotYetBeenPlaced,
     }),
     getters: {
         token(): string | undefined {
@@ -113,32 +118,32 @@ export const useAppStore = defineStore('app', {
             return this.isLoggedIn && this.activeUserRoleIsBuyer
         },
         /**
-         * Checks whether the address information for the order is complete.
+         * Checks whether the address information for the upcoming order is complete.
          * @returns - Returns true if both the delivery and billing addresses have valid IDs, otherwise returns false.
          */
         addressInformationIsComplete(): boolean {
             return (
-                this.order.deliveryAddress?.id != undefined &&
-                this.order.billingAddress?.id != undefined
+                this.upcomingOrder.deliveryAddress?.id != undefined &&
+                this.upcomingOrder.billingAddress?.id != undefined
             )
         },
         /**
-         * Checks whether the shipment information for the order is complete.
+         * Checks whether the shipment information for the upcoming order is complete.
          * @returns - Returns true if for each order item the shipment method has a valid ID, otherwise returns false.
          */
         shipmentInformationIsComplete(): boolean {
             return (
-                this.order.items?.filter(
+                this.upcomingOrder.items?.filter(
                     (orderItem) => orderItem.shipmentMethod?.id == undefined
                 ).length === 0
             )
         },
         /**
-         * Checks whether the payment information for the order is complete.
+         * Checks whether the payment information for the upcoming order is complete.
          * @returns - Returns true if the payment information has a valid ID, otherwise returns false.
          */
         paymentInformationIsComplete(): boolean {
-            return this.order.paymentInformation?.id != undefined
+            return this.upcomingOrder.paymentInformation?.id != undefined
         },
     },
     actions: {
@@ -514,21 +519,21 @@ export const useAppStore = defineStore('app', {
             await this.restoreTheShoppingCart()
         },
         /**
-         * Resets the order to a state where no information has been provided.
+         * Resets the upcoming order to a state where no information has been provided.
          */
-        resetOrderToUndefined() {
-            this.order = new OrderImpl()
+        resetUpcomingOrder() {
+            this.upcomingOrder = emptyOrderThatHasNotYetBeenPlaced
         },
         /**
          * Creates order items based on the items in the shopping cart and assigns them to the order.
          * If the order is undefined, the function returns without creating order items.
          */
         createOrderItems() {
-            if (this.order == undefined) {
+            if (this.upcomingOrder == undefined) {
                 return
             }
 
-            this.order.items = this.shoppingCart.items.map(
+            this.upcomingOrder.items = this.shoppingCart.items.map(
                 (shoppingCartItem) => new OrderItemImpl(shoppingCartItem)
             )
         },

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -155,10 +155,12 @@ export const useAppStore = defineStore('app', {
         paymentInformationIsComplete(): boolean {
             if (this.upcomingOrder.paymentInformation?.id != undefined) {
                 if (
-                    this.order.paymentInformation.paymentMethod ==
+                    this.upcomingOrder.paymentInformation.paymentMethod ==
                     PaymentMethod.CreditCard
                 ) {
-                    return this.order.creditCardValidationCode != undefined
+                    return (
+                        this.upcomingOrder.creditCardValidationCode != undefined
+                    )
                 } else {
                     return true
                 }

--- a/src/views/ShoppingCartView.vue
+++ b/src/views/ShoppingCartView.vue
@@ -84,7 +84,7 @@ async function removeShoppingCartItem(idOfShoppingCartItem: any) {
  * This function is typically called when the user wants to proceed to checkout.
  */
 function userWantsToProceedToCheckout(): void {
-    store.resetOrderToUndefined()
+    store.resetUpcomingOrder()
     store.createOrderItems()
 
     navigateToCheckoutView()

--- a/src/views/checkout/AddressInformationView.vue
+++ b/src/views/checkout/AddressInformationView.vue
@@ -34,7 +34,7 @@ import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'
 
 const store = useAppStore()
-const { order } = storeToRefs(store)
+const { upcomingOrder: order } = storeToRefs(store)
 
 const triggerForQueryingOfDeliveryAddresses = ref<number>(0)
 

--- a/src/views/checkout/OrderSummaryView.vue
+++ b/src/views/checkout/OrderSummaryView.vue
@@ -77,7 +77,7 @@ function closeConfirmOrCancelDialog(): void {
  */
 async function onUserConfirmedOrderPlacement(): Promise<void> {
     closeConfirmOrCancelDialog()
-    await placeOrderAndUpdateSummary()
+    await placeOrderAndTriggerSummaryUpdate()
 }
 
 /**
@@ -86,14 +86,14 @@ async function onUserConfirmedOrderPlacement(): Promise<void> {
 const isAwaitingOrderPlacement = ref(false)
 
 /**
- * Asynchronously places an order and updates the summary.
+ * Asynchronously places the order and triggers a summary update.
  * This function sets the state to indicate that an order placement is in progress,
  * places the order with the provided orderId, and then updates the state upon completion.
  * Additionally, it pushes a notification to the store indicating the success of the order placement
  * and triggers querying for updated order information.
  * @returns A Promise that resolves once the order is successfully placed and the summary is updated.
  */
-async function placeOrderAndUpdateSummary(): Promise<void> {
+async function placeOrderAndTriggerSummaryUpdate(): Promise<void> {
     isAwaitingOrderPlacement.value = true
     try {
         await placeOrder(props.orderId)
@@ -101,12 +101,13 @@ async function placeOrderAndUpdateSummary(): Promise<void> {
         throw error
     } finally {
         isAwaitingOrderPlacement.value = false
+        triggerForQueryingOfOrder.value++
     }
+    store.upcomingOrder.hasBeenPlaced = true
     store.pushNotification({
-        text: 'Your order was placed.',
+        text: 'Your order has been placed.',
         title: 'Thank You!',
         type: 'success',
     })
-    triggerForQueryingOfOrder.value++
 }
 </script>

--- a/src/views/checkout/OrderSummaryView.vue
+++ b/src/views/checkout/OrderSummaryView.vue
@@ -47,7 +47,7 @@ const props = defineProps({
 })
 
 const store = useAppStore()
-const { order } = storeToRefs(store)
+const { upcomingOrder } = storeToRefs(store)
 
 /**
  * A trigger for the querying of the order.
@@ -100,12 +100,12 @@ async function placeOrderAndTriggerSummaryUpdate(): Promise<void> {
     isAwaitingOrderPlacement.value = true
     try {
         if (
-            order.value.paymentInformation?.paymentMethod ===
+            upcomingOrder.value.paymentInformation?.paymentMethod ===
             PaymentMethod.CreditCard
         ) {
             await placeOrder(
                 props.orderId,
-                order.value.creditCardValidationCode
+                upcomingOrder.value.creditCardValidationCode
             )
         } else {
             await placeOrder(props.orderId)

--- a/src/views/checkout/PaymentInformationView.vue
+++ b/src/views/checkout/PaymentInformationView.vue
@@ -55,7 +55,7 @@ import { storeToRefs } from 'pinia'
 import { ref, watch } from 'vue'
 
 const store = useAppStore()
-const { order } = storeToRefs(store)
+const { upcomingOrder: order } = storeToRefs(store)
 
 /**
  * The total value of the order -- what the user would have to pay.

--- a/src/views/checkout/ShipmentInformationView.vue
+++ b/src/views/checkout/ShipmentInformationView.vue
@@ -26,5 +26,5 @@ import ShipmentMethodOfOrderItem from '@/components/ShipmentMethodOfOrderItem.vu
 import { useAppStore } from '@/store/app'
 import { storeToRefs } from 'pinia'
 
-const { order } = storeToRefs(useAppStore())
+const { upcomingOrder: order } = storeToRefs(useAppStore())
 </script>


### PR DESCRIPTION
### Summary of what has changed

The main requirement was to add a button at the checkout that would clearly tell the customer "Hey, click here to leave the checkout", right after the order has been placed. I modified the "CANCEL" button to display "LEAVE CHECKOUT" as soon as the order has been placed. I also modified the "BACK" button on the right side of the toolbar to not be there as soon as the user has arrived at the summary. I added stateful information to the order object in the App Store: From now on, the order object has a boolean flag indicating whether the order has already been placed. See the Gropius issue for more information regarding requirements.

[Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/129dc06e-4ec8-4389-90c5-34bea26006f5)

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented