### PR TITLE
Add input field for CVC

### DIFF
--- a/src/components/SelectOrAddNewCreditCardCard.vue
+++ b/src/components/SelectOrAddNewCreditCardCard.vue
@@ -11,17 +11,45 @@
             {{ selectedCreditCard?.secretMethodDetails }}<br />
         </v-card-text>
         <v-card-text>
-            <v-select
-                clearable
-                hint="Select one of your previously saved credit cards."
-                item-title="publicMethodDetails"
-                item-value="id"
-                :items="creditCards"
-                label="Credit Card"
-                :persistent-hint="!selectedCreditCard"
-                return-object
-                v-model="selectedCreditCard"
-            ></v-select>
+            <v-container>
+                <v-row>
+                    <v-col>
+                        <v-select
+                            clearable
+                            hint="Select one of your previously saved credit cards."
+                            item-title="publicMethodDetails"
+                            item-value="id"
+                            :items="creditCards"
+                            label="Credit Card"
+                            :persistent-hint="!selectedCreditCard"
+                            return-object
+                            v-model="selectedCreditCard"
+                        ></v-select>
+                    </v-col>
+                </v-row>
+                <v-row>
+                    <v-col cols="4">
+                        <v-text-field
+                            class="mt-4"
+                            clearable
+                            hint="You can find the CVC on the back of your card."
+                            label="Credit Card Validation Code (CVC)"
+                            :persistent-hint="
+                                order.creditCardValidationCode == undefined
+                            "
+                            prepend-icon="mdi-numeric"
+                            required
+                            :rules="[
+                                inputIsRequired,
+                                isValidCreditCardValidationCode,
+                            ]"
+                            type="input"
+                            variant="underlined"
+                            v-model="order.creditCardValidationCode"
+                        ></v-text-field>
+                    </v-col>
+                </v-row>
+            </v-container>
         </v-card-text>
         <v-card-actions>
             <v-spacer></v-spacer>
@@ -119,8 +147,10 @@ import {
     inputIsRequired,
     isValidCreditCardNumber,
     isValidCreditCardExpirationDate,
+    isValidCreditCardValidationCode,
 } from '@/util/rules'
 import { asyncComputed } from '@vueuse/core'
+import { storeToRefs } from 'pinia'
 import { computed, ref, watch } from 'vue'
 
 const props = defineProps({
@@ -149,6 +179,7 @@ watch(
 const emits = defineEmits(['update:creditCard', 'newCreditCardSaved'])
 
 const store = useAppStore()
+const { order } = storeToRefs(store)
 
 const client = useClient()
 

--- a/src/model/classes/orderImpl.ts
+++ b/src/model/classes/orderImpl.ts
@@ -14,13 +14,15 @@ export class OrderImpl implements Order {
      * @param [deliveryAddress] - The delivery address for the order.
      * @param [billingAddress] - The billing address for the order.
      * @param [paymentInformation] - The payment information for the order.
-     * @property [vatNumber] - The VAT number.
+     * @param [creditCardValidationCode] - If the payment method is credit card, the CVC of the chosen credit card.
+     * @param [vatNumber] - The VAT number.
      */
     constructor(
         public items?: OrderItem[],
         public deliveryAddress?: Address,
         public billingAddress?: Address,
         public paymentInformation?: PaymentInformation,
+        public creditCardValidationCode?: string,
         public vatNumber?: string
     ) {}
 

--- a/src/model/interfaces/order.ts
+++ b/src/model/interfaces/order.ts
@@ -9,6 +9,7 @@ import { PaymentInformation } from './PaymentInformation'
  * @property [deliveryAddress] - The delivery address for the order.
  * @property [billingAddress] - The billing address for the order.
  * @property [paymentInformation] - The payment information for the order.
+ * @property [creditCardValidationCode] - If the payment method is credit card, the CVC of the chosen credit card.
  * @property [vatNumber] - The VAT number.
  * @method calculateTotalCost - Calculates the total cost of the order.
  */
@@ -17,6 +18,7 @@ export interface Order {
     deliveryAddress?: Address
     billingAddress?: Address
     paymentInformation?: PaymentInformation
+    creditCardValidationCode?: string
     vatNumber?: string
     calculateTotalCost(): number
 }

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -20,6 +20,7 @@ import {
 } from './shoppingCartManagement'
 import { OrderImpl } from '@/model/classes/orderImpl'
 import { OrderItemImpl } from '@/model/classes/orderItemImpl'
+import { PaymentMethod } from '@/model/enums/paymentMethod'
 
 const defaultUserRole = UserRole.Buyer
 const initialUserRolesOfCurrentUser = [defaultUserRole]
@@ -147,7 +148,18 @@ export const useAppStore = defineStore('app', {
          * @returns - Returns true if the payment information has a valid ID, otherwise returns false.
          */
         paymentInformationIsComplete(): boolean {
-            return this.order.paymentInformation?.id != undefined
+            if (this.order.paymentInformation?.id != undefined) {
+                if (
+                    this.order.paymentInformation.paymentMethod ==
+                    PaymentMethod.CreditCard
+                ) {
+                    return this.order.creditCardValidationCode != undefined
+                } else {
+                    return true
+                }
+            } else {
+                return false
+            }
         },
     },
     actions: {

--- a/src/store/orderManagement.ts
+++ b/src/store/orderManagement.ts
@@ -4,6 +4,8 @@ import {
     CreateOrderMutation,
     OrderItemInput,
     OrderStatus,
+    PaymentAuthorizationInput,
+    PlaceOrderInput,
     PlaceOrderMutation,
 } from '@/graphql/generated'
 import { Order } from '@/model/interfaces/order'
@@ -97,16 +99,32 @@ function createInputObjectForOrderCreation(
 
 /**
  * Requests the placement of an order with the specified order ID.
+ * If the payment method of the order is credit card, a credit card validation code (CVC) must be specified.
+ * This function does not check whether the chosen payment method actually is credit card
+ * if a CVC was specified.
  * @param orderId - The ID of the order to be placed.
+ * @param [creditCardValidationCode] - The CVC of the credit card.
  * @throws Throws an error if there is any issue while placing the order.
  * @returns - A promise that resolves to true if the order was placed succesfully, false otherwise.
  */
-export async function placeOrder(orderId: string): Promise<boolean> {
+export async function placeOrder(
+    orderId: string,
+    creditCardValidationCode?: string
+): Promise<boolean> {
     if (orderId == undefined) {
         throw new Error('Cannot create PlaceOrderInput.')
     }
-    const placeOrderInput = {
+
+    const paymentAuthorizationInput: PaymentAuthorizationInput | undefined =
+        typeof creditCardValidationCode === 'string'
+            ? {
+                  cvc: Number.parseInt(creditCardValidationCode),
+              }
+            : undefined
+
+    const placeOrderInput: PlaceOrderInput = {
         id: orderId,
+        paymentAuthorization: paymentAuthorizationInput,
     }
     const placeOrderMutation: PlaceOrderMutation =
         await awaitActionAndPushErrorIfNecessary(() => {

--- a/src/util/rules.ts
+++ b/src/util/rules.ts
@@ -86,6 +86,26 @@ export function isValidCreditCardNumber(input: string): boolean | string {
 }
 
 /**
+ * Checks if the provided string is a valid credit card validation code.
+ * @param input - The CVC to validate.
+ * @returns True if the CVC is valid, otherwise returns false if the given input is not a string or an empty string,
+ * otherwise returns a string inidicating a validation error.
+ */
+export function isValidCreditCardValidationCode(
+    input: string
+): boolean | string {
+    if (typeof input !== 'string' || input.length === 0) {
+        return false
+    }
+
+    if ((input.length === 3 || input.length === 4) && isNumber(input)) {
+        return true
+    } else {
+        return 'Please enter a valid CVC, e.g. 128.'
+    }
+}
+
+/**
  * Checks if the provided string is a valid credit card expiration date in the MM/YY or MM/YYYY format.
  * @param input - The expiration date to validate.
  * @returns - Returns true if the input is a valid expiration date and is in the future,

--- a/src/views/checkout/OrderSummaryView.vue
+++ b/src/views/checkout/OrderSummaryView.vue
@@ -30,8 +30,10 @@
 <script lang="ts" setup>
 import ConfirmOrCancelDialog from '@/components/ConfirmOrCancelDialog.vue'
 import OrderCard from '@/components/OrderCard.vue'
+import { PaymentMethod } from '@/model/enums/paymentMethod'
 import { useAppStore } from '@/store/app'
 import { placeOrder } from '@/store/orderManagement'
+import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
 
 const props = defineProps({
@@ -45,6 +47,7 @@ const props = defineProps({
 })
 
 const store = useAppStore()
+const { order } = storeToRefs(store)
 
 /**
  * A trigger for the querying of the order.
@@ -96,7 +99,17 @@ const isAwaitingOrderPlacement = ref(false)
 async function placeOrderAndUpdateSummary(): Promise<void> {
     isAwaitingOrderPlacement.value = true
     try {
-        await placeOrder(props.orderId)
+        if (
+            order.value.paymentInformation?.paymentMethod ===
+            PaymentMethod.CreditCard
+        ) {
+            await placeOrder(
+                props.orderId,
+                order.value.creditCardValidationCode
+            )
+        } else {
+            await placeOrder(props.orderId)
+        }
     } catch (error) {
         throw error
     } finally {


### PR DESCRIPTION
- Extend Order interface and OrderImpl class to have new property for the credit card validation code (CVC)
- Add input field to SelectOrAddNewCreditCardCard.vue
- Modify logic in app store that checks whether the payment information is complete
- Add rule that checks the validity of a given CVC
- Modify placeOrder function to provide payment authorization information if necessary

[The corresponding Gropius Issue](https://frontend.gropius.duckdns.org/components/9d12d6ac-e85a-407c-bdff-a8321fb75d3a/issues/ef387860-be19-4378-8270-0ceceedfa13b)

Please note that when testing it, as of right now, a VATIN must be specified during checkout. Why? Because this feature branch does not have the changes of PR#59 which means that for creating an order a VATIN must be present.

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented