### PR TITLE
Activate proceed button of bottom toolbar

### DIFF
--- a/src/views/ShoppingCartView.vue
+++ b/src/views/ShoppingCartView.vue
@@ -28,7 +28,11 @@
             </template>
         </v-virtual-scroll>
     </div>
-    <ShoppingCartToolbar v-if="shoppingCart.items.length > 10" :total="total" />
+    <ShoppingCartToolbar
+        v-if="shoppingCart.items.length > 5"
+        :total="total"
+        @checkout-initiated="userWantsToProceedToCheckout"
+    />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
### Summary

The "PROCEED TO CHECKOUT" button of the bottom toolbar of the shopping cart view does not do anything. There is no reaction from the app when clicking it. That must be fixed: It must do the exact same thing that the button of the top toolbar does.

### Expected Behavior

As a user, when clicking the "PROCEED TO CHECKOUT" button of the bottom toolbar of the shopping cart view, I expect the checkout process to begin.

### Actual Behavior

Nothing happens...

### How to Reproduce it

Add a minimum of 10 items to the shopping cart. Navigate to the shopping cart. Scroll down to the bottom toolbar. On the right there is a "PROCEED TO CHECKOUT" button. Click the button and nothing will happen.

### Environment

- Google Chrome Webbrowser
- infrastructure-docker build at commit 9b826c796909a42a93347e64b62dca243af63ef5
- Docker Desktop version 4.27.2 (137060) on macOS

### Definition of Done
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented